### PR TITLE
Support for Laravel 5.5 + updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ composer require andersevenrud/laravel-1881
 
 ## Configuration
 
-In `config/app.php`:
+In Laravel 5.5 and up, the package will automatically register the service provider and facade.
+
+In L5.4 or below start by registering the package's the service provider and facade:
 
 ```
+// config/app.php
 
 'providers' => [
     Laravel\DM1881\DM1881ServiceProvider::class,
@@ -44,6 +47,7 @@ function something() {
 ```
 ## Changelog
 
+* **1.0.3** - Updated dependencies + added L5.5 auto discovery
 * **1.0.2** - Updated dependencies
 * **1.0.1** - Updated composer.json
 * **1.0.0** - Initial release

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In `config/app.php`:
 Then publish configurations:
 
 ```
-$ php artisan vendor:publish
+$ php artisan vendor:publish --provider="Laravel\DM1881\DM1881ServiceProvider"
 ```
 
 You now have `config/dm1881.php`.

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "andersevenrud/laravel-1881",
   "description": "Laravel Service Provider for 1881",
   "license": "MIT",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "authors": [
     {
       "name": "Anders Evenrud",
@@ -12,12 +12,22 @@
   ],
   "require": {
     "php": ">=5.6.4",
-    "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*",
-    "andersevenrud/1881": "^0.5.2"
+    "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
+    "andersevenrud/1881": "^0.5.5"
   },
   "autoload": {
     "psr-4": {
       "Laravel\\DM1881\\": "src"
     }
-  }
+  },
+  "extra": {
+    "laravel": {
+        "providers": [
+            "Laravel\\DM1881\\DM1881ServiceProvider"
+        ],
+        "aliases": {
+            "DM1881": "Laravel\\DM1881\\Facades\\DM1881"
+        }
+    }
+}
 }


### PR DESCRIPTION
Updated dependencies, and added support for Laravel 5.5 (including auto discovery of the package). 

Also changed the README. 

Suggesting to tag a 1.0.3 release.